### PR TITLE
Rename Upload method

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -37,7 +37,7 @@ def root():
     }), 200
 
 
-@app.route('/packages', methods=['POST'])
+@app.route('/upload', methods=['POST'])
 def upload_package():
     try:
         data = request.get_json()


### PR DESCRIPTION
Just to match what we have in the planning document, and since it might be a little confusing to have two endpoints with the same name.