### PR TITLE
0.5 is the min score required to be ingestible

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -304,7 +304,7 @@ def ingest_model():
           'https://huggingface.co/')
 
     Quality Thresholds (minimum 0.5):
-        All non-latency metrics from the rate behavior (computed via compute_all_metrics):
+        All non-latency metrics computed via compute_all_metrics:
         - license
         - ramp_up_time
         - bus_factor


### PR DESCRIPTION
Model ingest - Request the ingestion of a public HuggingFace model. To be ingestible, the package must score at least 0.5 on each of the non-latency metrics from the “rate” behavior. If ingestible, the command should proceed to a package upload.

https://github.com/rybkr/modelregistry/issues/24