### PR TITLE
Phase 3: Add permission enforcement and sensitive models features

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,10 +12,74 @@ if SRC_PATH not in sys.path:
 
 from api_server import app  # noqa: E402  (import after path adjustment)
 from storage import storage  # noqa: E402
+from auth import hash_password  # noqa: E402
+from registry_models import User  # noqa: E402
+from datetime import datetime, timezone  # noqa: E402
+import uuid  # noqa: E402
 
 
 @pytest.fixture
 def client():
+    """Test client with admin authentication token."""
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        storage.reset()
+        storage._activity_log.clear()  # type: ignore[attr-defined]
+        storage._log_entries.clear()  # type: ignore[attr-defined]
+
+        # Create test admin user with all permissions
+        test_user = User(
+            user_id=str(uuid.uuid4()),
+            username="test_admin",
+            password_hash=hash_password("test_password"),
+            permissions=["upload", "search", "download", "admin"],
+            is_admin=True,
+            created_at=datetime.now(timezone.utc)
+        )
+        storage.create_user(test_user)
+
+        # Authenticate and get token
+        response = client.put(
+            "/api/authenticate",
+            json={"user": {"name": "test_admin"}, "secret": {"password": "test_password"}}
+        )
+        token = response.get_json()
+
+        # Create a wrapper class to inject auth header automatically
+        class AuthenticatedClient:
+            def __init__(self, client, token):
+                self._client = client
+                self._token = token
+
+            def get(self, *args, **kwargs):
+                kwargs.setdefault('headers', {})['X-Authorization'] = self._token
+                return self._client.get(*args, **kwargs)
+
+            def post(self, *args, **kwargs):
+                kwargs.setdefault('headers', {})['X-Authorization'] = self._token
+                return self._client.post(*args, **kwargs)
+
+            def put(self, *args, **kwargs):
+                kwargs.setdefault('headers', {})['X-Authorization'] = self._token
+                return self._client.put(*args, **kwargs)
+
+            def delete(self, *args, **kwargs):
+                kwargs.setdefault('headers', {})['X-Authorization'] = self._token
+                return self._client.delete(*args, **kwargs)
+
+            def patch(self, *args, **kwargs):
+                kwargs.setdefault('headers', {})['X-Authorization'] = self._token
+                return self._client.patch(*args, **kwargs)
+
+        yield AuthenticatedClient(client, token)
+        storage.reset()
+        storage._activity_log.clear()  # type: ignore[attr-defined]
+        storage._log_entries.clear()  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def unauth_client():
+    """Test client without authentication for testing auth failure scenarios."""
     app.config["TESTING"] = True
     with app.test_client() as client:
         storage.reset()

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -16,15 +16,6 @@ from storage import storage
 
 
 @pytest.fixture
-def client():
-    app.config["TESTING"] = True
-    with app.test_client() as client:
-        storage.reset()
-        yield client
-        storage.reset()
-
-
-@pytest.fixture
 def mock_model_resource():
     """Create a mock ModelResource and Model for testing."""
     with (

--- a/test/test_ingest_upload.py
+++ b/test/test_ingest_upload.py
@@ -9,15 +9,6 @@ from api_server import app
 from storage import storage
 
 
-@pytest.fixture
-def client():
-    app.config["TESTING"] = True
-    with app.test_client() as client:
-        storage.reset()  # Reset before each test
-        yield client
-        storage.reset()  # Reset after each test
-
-
 def test_upload_csv_file_success(client):
     """Test successful CSV file upload with valid data."""
     csv_content = """name,version,metadata

--- a/test/test_list_packages_bug.py
+++ b/test/test_list_packages_bug.py
@@ -13,15 +13,6 @@ from datetime import datetime, timezone
 
 
 @pytest.fixture
-def client():
-    app.config["TESTING"] = True
-    with app.test_client() as client:
-        storage.reset()
-        yield client
-        storage.reset()
-
-
-@pytest.fixture
 def sample_packages(client):
     """Create sample packages for testing."""
     packages = [

--- a/test/test_model_ingest.py
+++ b/test/test_model_ingest.py
@@ -10,15 +10,6 @@ from storage import storage
 from metrics.base_metric import Metric
 
 
-@pytest.fixture
-def client():
-    app.config["TESTING"] = True
-    with app.test_client() as client:
-        storage.reset()  # Reset before each test
-        yield client
-        storage.reset()  # Reset after each test
-
-
 def create_mock_metrics(
     license_score=0.8,
     ramp_up_score=0.7,


### PR DESCRIPTION
Access Control:
- Add check_permission() helper for permission validation
- Enforce upload permission on create_artifact, ingest_model, ingest_upload
- Enforce search permission on list_artifacts, get_artifact, get_artifacts_by_name
- Enforce download permission on download endpoint

Sensitive Models:
- POST/PUT /api/artifact/model/<id>/sensitive - Mark/update sensitive status
- GET /api/artifact/model/<id>/sensitive - Query sensitive status
- DELETE /api/artifact/model/<id>/sensitive - Remove sensitive status
- GET /api/artifact/model/<id>/download-history - Get download history
- Execute Node.js monitoring scripts on sensitive model downloads
- Track download history with username and timestamp

Features Implemented:
- Permission-based access control (upload, search, download)
- Sensitive model marking and monitoring
- Node.js monitoring script execution on downloads
- Download history tracking with timestamps

NOT BREAKING ANY TEST CASES